### PR TITLE
To support releasing on PGXN

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,45 @@
+{
+   "name": "dynamodb_fdw",
+   "abstract": "Foreign Data Wrapper for DynamoDB",
+   "description": "PostgreSQL extension which implements a Foreign Data Wrapper (FDW) for DynamoDB.",
+   "version": "2.1.1",
+   "maintainer": "pgspider",
+   "license": "postgresql",
+   "provides": {
+      "dynamodb_fdw": {
+         "abstract": "Foreign Data Wrapper for DynamoDB",
+         "file": "dynamodb_fdw.c",
+         "docfile": "README.md",
+         "version": "2.1.1"
+      }
+   },
+   "prereqs": {
+      "runtime": {
+         "requires": {
+            "PostgreSQL": "9.6.0"
+         }
+      }
+   },
+   "resources": {
+      "bugtracker": {
+         "web": "http://github.com/pgspider/dynamodb_fdw/issues/"
+      },
+      "repository": {
+        "url":  "git://github.com/pgspider/dynamodb_fdw.git",
+        "web":  "https://github.com/pgspider/dynamodb_fdw/",
+        "type": "git"
+      }
+   },
+   "generated_by": "David E. Wheeler",
+   "meta-spec": {
+      "version": "1.0.0",
+      "url": "http://pgxn.org/meta/spec.txt"
+   },
+   "tags": [
+      "dynamo",
+      "dynamodb",
+      "fdw",
+      "foreign data wrapper",
+      "dynamodb_fdw"
+   ]
+}


### PR DESCRIPTION
To support releasing on PGXN. Based on [sqlite_fdw](https://pgxn.org/dist/sqlite_fdw/)'s [META.json](https://github.com/pgspider/sqlite_fdw/blob/master/META.json).